### PR TITLE
Mixed bc

### DIFF
--- a/inc/darcy_vtdd.h
+++ b/inc/darcy_vtdd.h
@@ -154,7 +154,7 @@ namespace vt_darcy
         //Boundary condition vector: D means Dirichlet bc, N means Neumann bc starting from left, bottom, right, top respectively.
         std::vector<char> bc_condition_vect;  //= {D, D, D, N} = {left, bottom, right} has Dirichlet boundayr condition and
 											//bottom has neumann bc( essential)
-        std::vector<int> dir_bc_id, nm_bc_id;
+        std::vector<int> dir_bc_ids, nm_bc_ids;
 
         unsigned int       gmres_iteration;
         // Number of subdomains in the computational domain

--- a/inc/darcy_vtdd.h
+++ b/inc/darcy_vtdd.h
@@ -154,6 +154,7 @@ namespace vt_darcy
         //Boundary condition vector: D means Dirichlet bc, N means Neumann bc starting from left, bottom, right, top respectively.
         std::vector<char> bc_condition_vect;  //= {D, D, D, N} = {left, bottom, right} has Dirichlet boundayr condition and
 											//bottom has neumann bc( essential)
+        std::vector<int> dir_bc_id, nm_bc_id;
 
         unsigned int       gmres_iteration;
         // Number of subdomains in the computational domain

--- a/inc/darcy_vtdd.h
+++ b/inc/darcy_vtdd.h
@@ -92,8 +92,8 @@ namespace vt_darcy
     {
     public:
         DarcyVTProblem(const unsigned int degree, const BiotParameters& bprm, const unsigned int mortar_flag = 0,
-                           const unsigned int mortar_degree = 0, std::vector<char> bc_condition_vect={'D','D','D','D'},
-						   std::vector<float>bc_const_functs={0.,0.,0.,0.});
+                           const unsigned int mortar_degree = 0, std::vector<char> nm_bc_condition_vect={'D','D','D','D'},
+						   std::vector<double>bc_const_functs={0.,0.,0.,0.});
 
         void run(const unsigned int refine,
         		 const std::vector <std::vector<int>> &reps_st, double tol,
@@ -155,7 +155,7 @@ namespace vt_darcy
         //Boundary condition vector: D means Dirichlet bc, N means Neumann bc starting from left, bottom, right, top respectively.
         std::vector<char> bc_condition_vect;  //= {D, D, D, N} = {left, bottom, right} has Dirichlet boundayr condition and
 											//bottom has neumann bc( essential)
-        std::vector<float> bc_const_functs; //vector containing v.n for Neumann boundary condition,
+        std::vector<double> nm_bc_const_functs; //vector containing v.n for Neumann boundary condition,
         									//in case its a constant fuction(this is assumed by default).
         std::vector<int> dir_bc_ids, nm_bc_ids;
 

--- a/inc/darcy_vtdd.h
+++ b/inc/darcy_vtdd.h
@@ -242,10 +242,13 @@ namespace vt_darcy
         BlockVector<double> old_pressure_projection; //pressure_projection from previous time step.
 
         BlockVector<double> system_rhs_bar;
+        BlockVector<double> system_rhs_bar_bc; //used in assemble_system: required for essential(Neumann bc)
         BlockVector<double> system_rhs_star;
 //        BlockVector<double> interface_fe_function; //need to decide whether to keep this.
         BlockVector<double> interface_fe_function_subdom;
 
+        //Constrain matrix for essential (Neumann) bc
+        ConstraintMatrix constraint_bc;
 
         // Mortar data structures
         BlockVector<double> interface_fe_function_mortar;

--- a/inc/darcy_vtdd.h
+++ b/inc/darcy_vtdd.h
@@ -92,7 +92,8 @@ namespace vt_darcy
     {
     public:
         DarcyVTProblem(const unsigned int degree, const BiotParameters& bprm, const unsigned int mortar_flag = 0,
-                           const unsigned int mortar_degree = 0, std::vector<char> bc_condition_vect={'D','D','D','D'});
+                           const unsigned int mortar_degree = 0, std::vector<char> bc_condition_vect={'D','D','D','D'},
+						   std::vector<float>bc_const_functs={0.,0.,0.,0.});
 
         void run(const unsigned int refine,
         		 const std::vector <std::vector<int>> &reps_st, double tol,
@@ -154,6 +155,8 @@ namespace vt_darcy
         //Boundary condition vector: D means Dirichlet bc, N means Neumann bc starting from left, bottom, right, top respectively.
         std::vector<char> bc_condition_vect;  //= {D, D, D, N} = {left, bottom, right} has Dirichlet boundayr condition and
 											//bottom has neumann bc( essential)
+        std::vector<float> bc_const_functs; //vector containing v.n for Neumann boundary condition,
+        									//in case its a constant fuction(this is assumed by default).
         std::vector<int> dir_bc_ids, nm_bc_ids;
 
         unsigned int       gmres_iteration;

--- a/inc/utilities.h
+++ b/inc/utilities.h
@@ -330,7 +330,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[3] < 0 )
-                        cell->face(face_number)->set_boundary_id (104);
+                        cell->face(face_number)->set_boundary_id (101);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (4);
@@ -342,7 +342,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[0] < 0 )
-                        cell->face(face_number)->set_boundary_id (101);
+                        cell->face(face_number)->set_boundary_id (102);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (1);
@@ -354,7 +354,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[1] < 0 )
-                        cell->face(face_number)->set_boundary_id (102);
+                        cell->face(face_number)->set_boundary_id (103);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (2);
@@ -366,7 +366,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[2] < 0 )
-                        cell->face(face_number)->set_boundary_id (103);
+                        cell->face(face_number)->set_boundary_id (104);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (3);
@@ -422,7 +422,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[3] < 0 )
-                            cell->face(face_number)->set_boundary_id (104);
+                            cell->face(face_number)->set_boundary_id (101);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (4);
@@ -434,7 +434,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[0] < 0 )
-                            cell->face(face_number)->set_boundary_id (101);
+                            cell->face(face_number)->set_boundary_id (102);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (1);
@@ -446,7 +446,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[1] < 0 )
-                            cell->face(face_number)->set_boundary_id (102);
+                            cell->face(face_number)->set_boundary_id (103);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (2);
@@ -458,7 +458,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[2] < 0 )
-                            cell->face(face_number)->set_boundary_id (103);
+                            cell->face(face_number)->set_boundary_id (104);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (3);

--- a/inc/utilities.h
+++ b/inc/utilities.h
@@ -330,7 +330,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[3] < 0 )
-                        cell->face(face_number)->set_boundary_id (0);
+                        cell->face(face_number)->set_boundary_id (104);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (4);
@@ -342,7 +342,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[0] < 0 )
-                        cell->face(face_number)->set_boundary_id (0);
+                        cell->face(face_number)->set_boundary_id (101);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (1);
@@ -354,7 +354,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[1] < 0 )
-                        cell->face(face_number)->set_boundary_id (0);
+                        cell->face(face_number)->set_boundary_id (102);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (2);
@@ -366,7 +366,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[2] < 0 )
-                        cell->face(face_number)->set_boundary_id (0);
+                        cell->face(face_number)->set_boundary_id (103);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (3);
@@ -377,7 +377,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[4] < 0 )
-                        cell->face(face_number)->set_boundary_id (0);
+                        cell->face(face_number)->set_boundary_id (105);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (5);
@@ -388,7 +388,7 @@ namespace vt_darcy
                 {
                     // If it is outside boundary (no neighbor) or interface
                     if (neighbors[5] < 0 )
-                        cell->face(face_number)->set_boundary_id (0);
+                        cell->face(face_number)->set_boundary_id (106);
                     else
                     {
                         cell->face(face_number)->set_boundary_id (6);
@@ -422,7 +422,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[3] < 0 )
-                            cell->face(face_number)->set_boundary_id (0);
+                            cell->face(face_number)->set_boundary_id (104);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (4);
@@ -434,7 +434,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[0] < 0 )
-                            cell->face(face_number)->set_boundary_id (0);
+                            cell->face(face_number)->set_boundary_id (101);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (1);
@@ -446,7 +446,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[1] < 0 )
-                            cell->face(face_number)->set_boundary_id (0);
+                            cell->face(face_number)->set_boundary_id (102);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (2);
@@ -458,7 +458,7 @@ namespace vt_darcy
                     {
                         // If it is outside boundary (no neighbor) or interface
                         if (neighbors[2] < 0 )
-                            cell->face(face_number)->set_boundary_id (0);
+                            cell->face(face_number)->set_boundary_id (103);
                         else
                         {
                             cell->face(face_number)->set_boundary_id (3);

--- a/parameter.txt
+++ b/parameter.txt
@@ -9,7 +9,7 @@ max_iteration: 500
 left_bc: D 0.0
 bottom_bc: D 0.0
 right_bc: D 0.0
-top_bc: D 0.0
+top_bc: D 1.0
 mesh_pattern_sub_d0: 3 3 3
 mesh_pattern_sub_d1: 2 2 2
 mesh_pattern_sub_d2: 4 4 4

--- a/parameter.txt
+++ b/parameter.txt
@@ -2,7 +2,7 @@ c0 1.0
 alpha 1.0
 space_degree 0
 mortar_degree 1
-num_refinement 4
+num_refinement 2
 final_time 0.5
 tolerence 1.e-6
 max_iteration 500

--- a/parameter.txt
+++ b/parameter.txt
@@ -1,17 +1,17 @@
-c0 1.0
-alpha 1.0
-space_degree 0
-mortar_degree 1
-num_refinement 2
-final_time 0.5
-tolerence 1.e-6
-max_iteration 500
-left_bc: D
-bottom_bc: D
-right_bc: D
-top_bc: D
-mesh_pattern_sub_d0 3 3 3
-mesh_pattern_sub_d1 2 2 2
-mesh_pattern_sub_d2 4 4 4
-mesh_pattern_sub_d3 3 3 3
-mesh_pattern_mortar 1 1 1
+c0: 1.0
+alpha: 1.0
+space_degree: 0
+mortar_degree: 1
+num_refinement: 2
+final_time: 0.5
+tolerence: 1.e-6
+max_iteration: 500
+left_bc: D 0.0
+bottom_bc: D 0.0
+right_bc: D 0.0
+top_bc: D 0.0
+mesh_pattern_sub_d0: 3 3 3
+mesh_pattern_sub_d1: 2 2 2
+mesh_pattern_sub_d2: 4 4 4
+mesh_pattern_sub_d3: 3 3 3
+mesh_pattern_mortar: 1 1 1

--- a/src/darcy_main.cc
+++ b/src/darcy_main.cc
@@ -46,6 +46,7 @@ int main (int argc, char *argv[])
 
         //boundary condition vector. 'D':Dirichlet, 'N': Neumann
         std::vector<char> bc_con(4,'D');
+        std::vector<float> bc_con_funcs(4,0.0);
         std::vector<char>possible_bc = {'D','N'};
 
         std::string dummy_string; //for getting rid of string in the parameter.dat
@@ -74,10 +75,10 @@ int main (int argc, char *argv[])
 				parameter_file>>dummy_string>>final_time;
 				parameter_file>>dummy_string>>tolerence;
 				parameter_file>>dummy_string>>max_iteration;
-				parameter_file>>dummy_string>>bc_con[0];
-				parameter_file>>dummy_string>>bc_con[1];
-				parameter_file>>dummy_string>>bc_con[2];
-				parameter_file>>dummy_string>>bc_con[3];
+				parameter_file>>dummy_string>>bc_con[0]>>bc_con_funcs[0];
+				parameter_file>>dummy_string>>bc_con[1]>>bc_con_funcs[1];
+				parameter_file>>dummy_string>>bc_con[2]>>bc_con_funcs[2];
+				parameter_file>>dummy_string>>bc_con[3]>>bc_con_funcs[3];
 				for(unsigned int sub_id=0; sub_id<n_processes+1; sub_id++)
 					parameter_file>>dummy_string>>mesh_m3d[sub_id][0]>>mesh_m3d[sub_id][1]>>mesh_m3d[sub_id][2];
 

--- a/src/darcy_main.cc
+++ b/src/darcy_main.cc
@@ -46,10 +46,11 @@ int main (int argc, char *argv[])
 
         //boundary condition vector. 'D':Dirichlet, 'N': Neumann
         std::vector<char> bc_con(4,'D');
-        std::vector<float> bc_con_funcs(4,0.0);
+        std::vector<double> nm_bc_con_funcs(4,0.0);
         std::vector<char>possible_bc = {'D','N'};
 
         std::string dummy_string; //for getting rid of string in the parameter.dat
+//        std::vector<double> nm_bc_catch(4, 0.0); //for catching the constant functions corresponding to neumann bc.
         {//Reading parameters from parameter.dat file
             MPI_Comm mpi_communicator_1(MPI_COMM_WORLD);
             MPI_Status mpi_status_1;
@@ -75,10 +76,10 @@ int main (int argc, char *argv[])
 				parameter_file>>dummy_string>>final_time;
 				parameter_file>>dummy_string>>tolerence;
 				parameter_file>>dummy_string>>max_iteration;
-				parameter_file>>dummy_string>>bc_con[0]>>bc_con_funcs[0];
-				parameter_file>>dummy_string>>bc_con[1]>>bc_con_funcs[1];
-				parameter_file>>dummy_string>>bc_con[2]>>bc_con_funcs[2];
-				parameter_file>>dummy_string>>bc_con[3]>>bc_con_funcs[3];
+				parameter_file>>dummy_string>>bc_con[0]>>nm_bc_con_funcs[0];
+				parameter_file>>dummy_string>>bc_con[1]>>nm_bc_con_funcs[1];
+				parameter_file>>dummy_string>>bc_con[2]>>nm_bc_con_funcs[2];
+				parameter_file>>dummy_string>>bc_con[3]>>nm_bc_con_funcs[3];
 				for(unsigned int sub_id=0; sub_id<n_processes+1; sub_id++)
 					parameter_file>>dummy_string>>mesh_m3d[sub_id][0]>>mesh_m3d[sub_id][1]>>mesh_m3d[sub_id][2];
 
@@ -98,10 +99,16 @@ int main (int argc, char *argv[])
         			"Dirichlet or Neumann boundary condition is desired\n");
         }
 
+//        //Getttng rid of constant function input corresponding to dirichlet bc
+//        //(since this is a natural bc and hence  not required).
+//        for (int i=0; i<4; ++i)
+//        	if (bc_con[i] == 'N')
+//        			nm_bc_con_funcs.push_back(nm_bc_catch[i]);
+
         BiotParameters bparam (1.0,1,final_time,c_0,alpha);
 
         //Solving the problem.
-        DarcyVTProblem<2> problem_2d(space_degree,bparam,1,mortar_degree, bc_con);
+        DarcyVTProblem<2> problem_2d(space_degree,bparam,1,mortar_degree, bc_con, nm_bc_con_funcs);
         problem_2d.run(num_refinement,mesh_m3d,tolerence,max_iteration,mortar_degree+1);
 
 

--- a/src/darcy_vtdd.cc
+++ b/src/darcy_vtdd.cc
@@ -403,7 +403,7 @@ namespace vt_darcy
                 for (unsigned int face_n=0;
                      face_n<GeometryInfo<dim>::faces_per_cell;
                      ++face_n)
-                    if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() != 0)
+                    if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() < 100)
                     {
                         cell->face(face_n)->get_dof_indices (local_face_dof_indices, 0);
 
@@ -423,7 +423,7 @@ namespace vt_darcy
                 for (unsigned int face_n=0;
                      face_n<GeometryInfo<dim>::faces_per_cell;
                      ++face_n)
-                    if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() != 0)
+                    if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() < 100)
                     {
                         cell->face(face_n)->get_dof_indices (local_face_dof_indices, 0);
                         for (auto el : local_face_dof_indices)
@@ -466,7 +466,7 @@ namespace vt_darcy
 				//end of getting face dofs
 
 					//start of getting interface dofs.
-					if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() != 0)
+					if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() < 100)
 					{
 
 						for (auto el : local_face_dof_indices)
@@ -506,7 +506,7 @@ namespace vt_darcy
                     //end of getting face dofs
 
             	//start of getting interface dofs
-                if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() != 0)
+                if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() < 100)
                 {
                     for (auto el : local_face_dof_indices){
                             interface_dofs_st[cell->face(face_n)->boundary_id()-1].push_back(el);
@@ -604,7 +604,7 @@ namespace vt_darcy
           for (unsigned int face_no=0;
                face_no<GeometryInfo<dim>::faces_per_cell;
                ++face_no)
-              if (cell->at_boundary(face_no) && cell->face(face_no)->boundary_id() == 0) // pressure part of the boundary
+              if (cell->at_boundary(face_no) && cell->face(face_no)->boundary_id() > 100) // pressure part of the boundary
               {
                   fe_face_values.reinit (cell, face_no);
 
@@ -692,7 +692,7 @@ namespace vt_darcy
             for (unsigned int face_n=0;
                  face_n<GeometryInfo<dim>::faces_per_cell;
                  ++face_n)
-                if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() != 0)
+                if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() < 100)
                 {
                     fe_face_values.reinit (cell, face_n);
                     fe_face_values[velocity].get_function_values (interface_fe_function_subdom, interface_values_flux);
@@ -1451,7 +1451,7 @@ namespace vt_darcy
             for (unsigned int face_n=0;
                  face_n<GeometryInfo<dim>::faces_per_cell;
                  ++face_n)
-                if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() != 0)
+                if (cell->at_boundary(face_n) && cell->face(face_n)->boundary_id() < 100)
                 {
                     fe_face_values.reinit (cell, face_n);
                     fe_face_values[velocity].get_function_values (interface_fe_function_mortar, interface_values_flux);

--- a/src/darcy_vtdd.cc
+++ b/src/darcy_vtdd.cc
@@ -60,7 +60,8 @@ namespace vt_darcy
                                                  const BiotParameters &bprm,
                                                  const unsigned int mortar_flag,
                                                  const unsigned int mortar_degree,
-												 std::vector<char> bc_condition_vect)
+												 std::vector<char> bc_condition_vect,
+												 std::vector<float>bc_const_functs)
             :
             mpi_communicator (MPI_COMM_WORLD),
             P_coarse2fine (false),
@@ -68,6 +69,7 @@ namespace vt_darcy
             n_domains(dim,0),
             prm (bprm),
 			bc_condition_vect (bc_condition_vect),
+			bc_const_functs (bc_const_functs),
             degree (degree),
             mortar_degree(mortar_degree),
             mortar_flag (mortar_flag),

--- a/src/darcy_vtdd.cc
+++ b/src/darcy_vtdd.cc
@@ -180,6 +180,12 @@ namespace vt_darcy
 
         //Adding essential Neumann BC
         {
+        	for (int i=0; i<bc_condition_vect.size(); ++i){
+        		if (bc_condition_vect[i] == 'D')
+        				dir_bc_id.push_back(100+i+1); // Dirichlet bc: left: 101, bottom: 102, right: 103, top:104
+				else if (bc_condition_vect[i] == 'N')
+					nm_bc_id.push_back(100+i+1);   // Neumann bc: left: 101, bottom: 102, right: 103, top:104
+        	}
         	constraint_bc.clear();
         }
         constraint_bc.close();


### PR DESCRIPTION
Added the mixed boundary condition functinality. Details are hidden from the user inside the darcy_vtdd.cc in DarcyVTProblem::make_grid_and_dofs(). Users can use this feature by modifying the parameter file like in the following example:  
```
left_bc: D 0.0  
bottom_bc: N 0.0  
right_bc: D 0.0  
top_bc: N 1.0  
```
The above input in the parameter.txt file means velocity.n=0 and velocity.n=1 on the bottom and bottom boundary repescitvely. 