### PR TITLE
Fixed #28 issue with resizing of the gmres matrix

### DIFF
--- a/src/darcy_vtdd.cc
+++ b/src/darcy_vtdd.cc
@@ -1278,7 +1278,7 @@ namespace vt_darcy
           while (k_counter < maxiter)
             {
         	  //resizing cs,sn, Beta,H and Q if needed
-        	  if(temp_array_size<k_counter-2){
+        	  if(temp_array_size<k_counter+2){
         		  temp_array_size*=2;
         		  cs.resize(temp_array_size);
         		  sn.resize(temp_array_size);


### PR DESCRIPTION
@MichelKern pointed out bug in resizing the gmres array size. calculating negative values using unsigned int was avoided. This closes #28 .