### PR TITLE
Bug fix: Fix to stop the code from crashing when number of subdomain is 1

### DIFF
--- a/src/darcy_vtdd.cc
+++ b/src/darcy_vtdd.cc
@@ -873,7 +873,8 @@ namespace vt_darcy
 			  prm.time=0.0;
 
 			  pcout << "\nStarting GMRES iterations.........\n";
-			  local_gmres(maxiter);
+			  if (Utilities::MPI::n_mpi_processes(mpi_communicator) != 1)
+				  local_gmres(maxiter);
     }
 
     template<int dim>


### PR DESCRIPTION
Just added a condition 
``` if (Utilities::MPI::n_mpi_processes(mpi_communicator) != 1)```
before callign `local_gmres(maxiter)` inside `DarcyVTProblem<dim>::solve_darcy_vt(unsigned int maxiter)`.